### PR TITLE
Voltage levels fix

### DIFF
--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -66,7 +66,7 @@ float BATTERY::readBatteryAndCalcValue(){
   #if BOARD_VERSION == 10
     float reading = 1.1 +  (readValue * (13.3 / ANALOG_RESOLUTION_MAX_VALUE));
   #elif BOARD_VERSION == 11
-    float reading = (R_IN+R_GND)/R_GND * (readValue * (ADC_LINEAR_MAX_V-ADC_DETECTION_V)/ADC_LINEAR_MAX_READING + ADC_DETECTION_V);
+    float reading = VOLT_DIV * (readValue * (ADC_LINEAR_MAX_V-ADC_DETECTION_V)/ADC_LINEAR_MAX_READING + ADC_DETECTION_V);
   #endif
   return reading;
 }

--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -66,8 +66,7 @@ float BATTERY::readBatteryAndCalcValue(){
   #if BOARD_VERSION == 10
     float reading = 1.1 +  (readValue * (13.3 / ANALOG_RESOLUTION_MAX_VALUE));
   #elif BOARD_VERSION == 11
-    // float reading = 0.85 +  (readValue * (16.5 / ANALOG_RESOLUTION_MAX_VALUE));
-    float reading = (R_IN+R_GND)/R_GND * readValue * (3.3/ANALOG_RESOLUTION_MAX_VALUE);
+    float reading = (R_IN+R_GND)/R_GND * (readValue * (ADC_LINEAR_MAX_V-ADC_DETECTION_V)/ADC_LINEAR_MAX_READING + ADC_DETECTION_V);
   #endif
   return reading;
 }

--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -66,7 +66,8 @@ float BATTERY::readBatteryAndCalcValue(){
   #if BOARD_VERSION == 10
     float reading = 1.1 +  (readValue * (13.3 / ANALOG_RESOLUTION_MAX_VALUE));
   #elif BOARD_VERSION == 11
-    float reading = 0.85 +  (readValue * (16.5 / ANALOG_RESOLUTION_MAX_VALUE));
+    // float reading = 0.85 +  (readValue * (16.5 / ANALOG_RESOLUTION_MAX_VALUE));
+    float reading = (R_IN+R_GND)/R_GND * readValue * (3.3/ANALOG_RESOLUTION_MAX_VALUE);
   #endif
   return reading;
 }

--- a/src/battery.h
+++ b/src/battery.h
@@ -15,13 +15,15 @@
 #include "utils.h"
 
 // Voltages should be specified in V
-#define BATTERY_FULL       12.560
-#define BATTERY_EMPTY      10.400
+#define BATTERY_FULL       15.000 //TODO: Change when changing to new battery!
+#define BATTERY_EMPTY      13.600 //TODO: Change when changing to new battery!
 
 // Running average sample size
 #define FILTER        2000
 
-#define VOLTDIVATOR   4.33
+// Voltage divider resistors (Same for both battery and charge connections)
+#define R_IN    330000  // Resistance in ohm of resistor connected between battery+ and analog input pin.
+#define R_GND   82000   // Resistance in ohm of resistor connected between GND and analog input pin.
 
 class BATTERY {
   public:

--- a/src/battery.h
+++ b/src/battery.h
@@ -21,15 +21,28 @@
 // Running average sample size
 #define FILTER        2000
 
-// Voltage divider resistors (Same for both battery and charge connections)
-#define R_IN    330000  // Resistance in ohm of resistor connected between battery+ and analog input pin.
-#define R_GND   82000   // Resistance in ohm of resistor connected between GND and analog input pin.
+// Uncomment below to choose between theoretical values for the voltage divider or emperical values (by measureing the input voltage and between R36 & R50):
+// #define VOLTDIV_THEO
+#define VOLTDIV_EMPE
+
+#ifdef VOLTDIV_THEO
+  // Voltage divider resistors (Same for both battery and charge connections)
+  #define R_IN    330000  // Resistance in ohm of resistor connected between battery+ and analog input pin.
+  #define R_GND   82000   // Resistance in ohm of resistor connected between GND and analog input pin.
+  #define VOLT_DIV ((R_IN+R_GND)/R_GND)
+#endif
+
+#ifdef VOLTDIV_EMPE
+  #define MEASURED_INPUT_V  13.94
+  #define MEASURED_DIV_V    2.750  // Voltage to GND from between R36 & R50
+  #define VOLT_DIV (MEASURED_INPUT_V/MEASURED_DIV_V)
+#endif
 
 // ADC Calibrations (Used for rough compensation for the nonlinear and not factory calibrated adc in ESP32)
-#define ADC_SATURATION_V 3.195 // Not used in calculations, but good to have for future reference
-#define ADC_LINEAR_MAX_V 2.75 // Voltage on gpio when readings starts to become exponential
-#define ADC_LINEAR_MAX_READING 1630
-#define ADC_DETECTION_V 0.21
+#define ADC_SATURATION_V 3.195    // Not used in calculations, but good to have for future reference
+#define ADC_LINEAR_MAX_V 2.75     // Voltage on gpio when readings starts to become exponential
+#define ADC_LINEAR_MAX_READING 1650 // ADC reading at ADC_LINEAR_MAX_V
+#define ADC_DETECTION_V 0.21      // Online sources claim 0.15V, but by raising this value the slope of the linear approximation is increased, and the accuracy for both low and high input voltages is improved. 
 
 class BATTERY {
   public:

--- a/src/battery.h
+++ b/src/battery.h
@@ -15,8 +15,8 @@
 #include "utils.h"
 
 // Voltages should be specified in V
-#define BATTERY_FULL       15.000 //TODO: Change when changing to new battery!
-#define BATTERY_EMPTY      13.600 //TODO: Change when changing to new battery!
+#define BATTERY_FULL       12.560 //TODO: Change according to actual battery used!
+#define BATTERY_EMPTY      10.400 //TODO: Change according to actual battery used!
 
 // Running average sample size
 #define FILTER        2000
@@ -24,6 +24,12 @@
 // Voltage divider resistors (Same for both battery and charge connections)
 #define R_IN    330000  // Resistance in ohm of resistor connected between battery+ and analog input pin.
 #define R_GND   82000   // Resistance in ohm of resistor connected between GND and analog input pin.
+
+// ADC Calibrations (Used for rough compensation for the nonlinear and not factory calibrated adc in ESP32)
+#define ADC_SATURATION_V 3.195 // Not used in calculations, but good to have for future reference
+#define ADC_LINEAR_MAX_V 2.75 // Voltage on gpio when readings starts to become exponential
+#define ADC_LINEAR_MAX_READING 1630
+#define ADC_DETECTION_V 0.21
 
 class BATTERY {
   public:

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -54,11 +54,13 @@ typedef std::function<void()> RebootNeededEvent;
 #define AUX_MOTOR_PWM_CHANNEL_BACKWARDS 6
 #define AUX_MOTOR_SENSE_PIN 39
 
-#define LOAD_START_IGNORE_TIME 500
+// Load Limit unit conversion:
+// 0.1ohm shunt, 16 Gain Op-Amp, 11 bit (nonlinear) adc setting =>  1 mA ~= 1 load limit value
 #define LOAD_LIMIT_WHEEL 160
 #define LOAD_LIMIT_CUTTER 940
-#define LOAD_FILTER 0.01
 #define LOAD_LIMIT_AUX 200
+#define LOAD_START_IGNORE_TIME 500
+#define LOAD_FILTER 0.01
 
 #define LEFT_SENSOR_PIN 26
 #define RIGHT_SENSOR_PIN 25


### PR DESCRIPTION
Changed how measured battery voltages are calculated from ADC readings.
This was done to improve readability of the code and give a logical explanation of all numbers used in the calculation while maintaining a connection to the actual hardware used.
This gives the ability to quickly do small adjustments to defined values when switching hardware components. For example if the resistors in the voltage divider is changed to allow for a higher max voltage.

A optional section for manual calibration of the actual voltage divider was also added to compensate for the tolerance in manufacturing of the resistors used.

The new calculations has been tested with a stock LiaNG v1.1 board and confirmed to yield similar accuracy. 
See logged test measurements below.
(No tests has yet been done with other resistors and higher voltages.)

| **Input** | **Displayed - Old** | **Displayed - New** |
|-----------|---------------------|---------------------|
| 15.00     | 15.57               | 15.36               |
| 14.00     | 14.19               | 14.00               |
| 13.00     | 13.06               | 12.92               |
| 12.00     | 12.05               | 11.93               |
| 11.00     | 11.05               | 10.95               |
| 10.00     | 10.08               | 10.00               |
| 9.00      | 9.12                | 9.06                |
